### PR TITLE
Added Support for Ui Info Suite

### DIFF
--- a/BundleTooltips/ModEntry.cs
+++ b/BundleTooltips/ModEntry.cs
@@ -26,6 +26,8 @@ namespace StardewValleyBundleTooltips
         // check if a mod is loaded
         bool isCJBSellItemPriceLoaded;
 
+        private bool isUiInfoSuiteLoaded; //Check to see if UiInfoSuiteIsLoaded
+
         Item toolbarItem;
         List<int> itemsInBundles;
         Dictionary<int, int[][]> bundles;
@@ -42,6 +44,7 @@ namespace StardewValleyBundleTooltips
         public override void Entry(IModHelper helper)
         {
             isCJBSellItemPriceLoaded = this.Helper.ModRegistry.IsLoaded("CJBok.ShowItemSellPrice");
+            isUiInfoSuiteLoaded = this.Helper.ModRegistry.IsLoaded("Cdaragorn.UiInfoSuite");
 
             SaveEvents.AfterLoad += this.SaveEvents_AfterLoad;
             GraphicsEvents.OnPostRenderGuiEvent += GraphicsEvents_OnPostRenderGuiEvent;
@@ -208,7 +211,7 @@ namespace StardewValleyBundleTooltips
             int y = (int)(Mouse.GetState().Y / Game1.options.zoomLevel) + Game1.tileSize / 2;
 
             //So that the tooltips don't overlap
-            if (isCJBSellItemPriceLoaded && !isItFromToolbar)
+            if ((isCJBSellItemPriceLoaded || isUiInfoSuiteLoaded) && !isItFromToolbar)
             {
                 if (itemStack > 1)
                     y += 95;

--- a/BundleTooltips/manifest.json
+++ b/BundleTooltips/manifest.json
@@ -4,7 +4,7 @@
   "Version": {
     "MajorVersion": 1,
     "MinorVersion": 0,
-    "PatchVersion": 8,
+    "PatchVersion": 9,
     "Build": null
   },
   "Description": "Adding a tooltip to items telling you if they are needed in a bundle.",

--- a/BundleTooltips/manifest.json
+++ b/BundleTooltips/manifest.json
@@ -4,7 +4,7 @@
   "Version": {
     "MajorVersion": 1,
     "MinorVersion": 0,
-    "PatchVersion": 9,
+    "PatchVersion": 10,
     "Build": null
   },
   "Description": "Adding a tooltip to items telling you if they are needed in a bundle.",


### PR DESCRIPTION
Added support for UI Info Suite. Now if either CJB Item Sell Price OR Ui Info Suite is installed, it moves the tool tip down.